### PR TITLE
상품 엔티티(Item) JPA 매핑 추 가

### DIFF
--- a/src/main/java/com/SpringMall/entity/Item.java
+++ b/src/main/java/com/SpringMall/entity/Item.java
@@ -1,23 +1,41 @@
 package com.SpringMall.entity;
 
 import com.SpringMall.constant.ItemSellStaus;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
 import java.time.LocalDateTime;
 
+@Entity
+@Table(name="item")
 @Getter
 @Setter
 @ToString
 public class Item {
 
+    @Id
+    @Column(name = "item_id")
+    @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id; // 상품 코드
+
+    @Column(nullable = false, length = 50) // not null 설정 , 길이 = 50
     private String itemNm; // 상품명
+
+    @Column(name = "price", nullable = false)
     private int price; // 가격
+
+    @Column(nullable = false)
     private int stockNumber; // 재고수량
+
+    @Lob
+    @Column(nullable = false)
     private String itemDetail; // 상품 상세 설명
+
+    @Enumerated(EnumType.STRING)
     private ItemSellStaus itemSellStaus; // 상품 판매 상태
+
     private LocalDateTime regTime; // 등록 시간
     private LocalDateTime updateTime; // 수정 시간
 

--- a/src/main/java/com/SpringMall/entity/Item.java
+++ b/src/main/java/com/SpringMall/entity/Item.java
@@ -1,13 +1,26 @@
 package com.SpringMall.entity;
 
+import com.SpringMall.constant.ItemSellStaus;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+
+import java.time.LocalDateTime;
 
 @Getter
 @Setter
 @ToString
 public class Item {
+
+    private Long id; // 상품 코드
+    private String itemNm; // 상품명
+    private int price; // 가격
+    private int stockNumber; // 재고수량
+    private String itemDetail; // 상품 상세 설명
+    private ItemSellStaus itemSellStaus; // 상품 판매 상태
+    private LocalDateTime regTime; // 등록 시간
+    private LocalDateTime updateTime; // 수정 시간
+
 }
 
 


### PR DESCRIPTION
- 상품 엔티티(Item) JPA 매핑 추가
- @Entity 및 @Table(name="item") 설정
- ID 자동 생성 (@GeneratedValue) 및 칼럼 제약 조건 추가
- EnumType.STRING을 활용한 상품 판매 상태 저장
