### PR TITLE
feat: 상품 엔티티 관리용 ItemRepository 인터페이스 추가

### DIFF
--- a/src/main/java/com/SpringMall/entity/Item.java
+++ b/src/main/java/com/SpringMall/entity/Item.java
@@ -17,7 +17,7 @@ public class Item {
 
     @Id
     @Column(name = "item_id")
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.AUTO) // JPA 구현체가 자동으로 생성 전략 결정 (JPA가 사용자 대신 적절한 방식을 선택)
     private Long id; // 상품 코드
 
     @Column(nullable = false, length = 50) // not null 설정 , 길이 = 50

--- a/src/main/java/com/SpringMall/repository/ItemRepository.java
+++ b/src/main/java/com/SpringMall/repository/ItemRepository.java
@@ -1,0 +1,17 @@
+package com.SpringMall.repository;
+
+import com.SpringMall.entity.Item;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ItemRepository extends JpaRepository<Item, Long> {
+    /* JpaRepository<T,ID> : 2개의 제네릭 타입을 사용하는데
+                             첫 번째에는 엔티티 타입 클래스
+                             두 번째에는 기본키 타입을 넣어줌
+
+      [ JpaRepository 에서 지원하는 메소드 ]
+      1. <S extends T> save(S entity) : 엔티티 저장 및 수정
+      2. void delete(T entity) : 엔티티 삭제
+      3. count() : 엔티티 총 개수 반환
+      4. Iterable<T> findAll() : 모든 엔티티 조회
+    */
+}


### PR DESCRIPTION
Merge: 데이터베이스 작업을 위한 ItemRepository 추가

이 병합은 Item 엔티티에 대한 CRUD 작업을 수행할 수 있도록
JpaRepository를 상속받는 ItemRepository 인터페이스를 추가합니다.
이 저장소는 추가 구현 없이 저장, 삭제, 전체 조회, 개수 세기 등의
표준 메서드를 제공합니다. 향후 아이템 필터링 및 고급 검색 기능을 위한
사용자 정의 쿼리 메서드가 추가될 예정입니다.

Related ticket: #3